### PR TITLE
fix(group-label): Fix single label lookup

### DIFF
--- a/group_label.go
+++ b/group_label.go
@@ -7,12 +7,12 @@ type GroupLabels []GroupLabel
 
 // GroupLabel - label
 type GroupLabel struct {
-	GroupLabelName string      `json:"name,omitempty"`
-	GroupLabelID   int         `json:"groupId,omitempty"`
-	BuiltIn        int         `json:"builtin,omitempty"`
-	GroupLabelType string      `json:"type,omitempty"`
-	Agents         Agents      `json:"agents,omitempty"`
-	Tests          interface{} `json:"tests,omitempty"`
+	Name    string      `json:"name,omitempty"`
+	GroupID int         `json:"groupId,omitempty"`
+	BuiltIn int         `json:"builtin,omitempty"`
+	Type    string      `json:"type,omitempty"`
+	Agents  []Agents    `json:"agents,omitempty"`
+	Tests   interface{} `json:"tests,omitempty"`
 }
 
 // GetGroupLabels - Get labels

--- a/group_label.go
+++ b/group_label.go
@@ -51,14 +51,15 @@ func (c *Client) GetGroupLabel(id int) (*GroupLabel, error) {
 	}
 	var target map[string][]GroupLabel
 	if dErr := c.decodeJSON(resp, &target); dErr != nil {
-		return nil, fmt.Errorf("Could not decode JSON response: %v", dErr)
+		return nil, fmt.Errorf("could not decode JSON response: %v more error %+v", dErr, dErr.Error())
 	}
 	return &target["groups"][0], nil
 }
 
 // CreateGroupLabel - Create label
 func (c Client) CreateGroupLabel(a GroupLabel) (*GroupLabel, error) {
-	resp, err := c.post("/groups/new", a, nil)
+	path := fmt.Sprintf("/groups/%s/new", a.Type)
+	resp, err := c.post(path, a, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/group_label.go
+++ b/group_label.go
@@ -43,22 +43,21 @@ func (c *Client) GetGroupLabelsByType(t string) (*GroupLabels, error) {
 	return &labels, nil
 }
 
-// GetGroupLabelsByID - Get label
-func (c *Client) GetGroupLabelsByID(id int) (*GroupLabels, error) {
+// GetGroupLabel - Get single group label by ID
+func (c *Client) GetGroupLabel(id int) (*GroupLabel, error) {
 	resp, err := c.get(fmt.Sprintf("/groups/%d", id))
 	if err != nil {
-		return &GroupLabels{}, err
+		return &GroupLabel{}, err
 	}
-	var target map[string]GroupLabels
+	var target map[string][]GroupLabel
 	if dErr := c.decodeJSON(resp, &target); dErr != nil {
 		return nil, fmt.Errorf("Could not decode JSON response: %v", dErr)
 	}
-	labels := target["groups"]
-	return &labels, nil
+	return &target["groups"][0], nil
 }
 
 // CreateGroupLabel - Create label
-func (c Client) CreateGroupLabel(a GroupLabel) (*GroupLabels, error) {
+func (c Client) CreateGroupLabel(a GroupLabel) (*GroupLabel, error) {
 	resp, err := c.post("/groups/new", a, nil)
 	if err != nil {
 		return nil, err
@@ -72,9 +71,7 @@ func (c Client) CreateGroupLabel(a GroupLabel) (*GroupLabels, error) {
 	if dErr := c.decodeJSON(resp, &target); dErr != nil {
 		return nil, fmt.Errorf("Could not decode JSON response: %v", dErr)
 	}
-	labels := target["groups"]
-
-	return &labels, nil
+	return &target["groups"][0], nil
 }
 
 //DeleteGroupLabel - delete label

--- a/group_label.go
+++ b/group_label.go
@@ -7,12 +7,12 @@ type GroupLabels []GroupLabel
 
 // GroupLabel - label
 type GroupLabel struct {
-	Name    string      `json:"name,omitempty"`
-	GroupID int         `json:"groupId,omitempty"`
-	BuiltIn int         `json:"builtin,omitempty"`
-	Type    string      `json:"type,omitempty"`
-	Agents  []Agent     `json:"agents,omitempty"`
-	Tests   interface{} `json:"tests,omitempty"`
+	Name    string        `json:"name,omitempty"`
+	GroupID int           `json:"groupId,omitempty"`
+	BuiltIn int           `json:"builtin,omitempty"`
+	Type    string        `json:"type,omitempty"`
+	Agents  []Agent       `json:"agents,omitempty"`
+	Tests   []GenericTest `json:"tests,omitempty"`
 }
 
 // GetGroupLabels - Get labels
@@ -59,6 +59,9 @@ func (c *Client) GetGroupLabel(id int) (*GroupLabel, error) {
 // CreateGroupLabel - Create label
 func (c Client) CreateGroupLabel(a GroupLabel) (*GroupLabel, error) {
 	path := fmt.Sprintf("/groups/%s/new", a.Type)
+	// Now we must set Type to blank.  Because even though it's required to know the submit path,
+	// TE will return an error if we also submit it a part of the object.
+	a.Type = ""
 	resp, err := c.post(path, a, nil)
 	if err != nil {
 		return nil, err

--- a/group_label.go
+++ b/group_label.go
@@ -11,7 +11,7 @@ type GroupLabel struct {
 	GroupID int         `json:"groupId,omitempty"`
 	BuiltIn int         `json:"builtin,omitempty"`
 	Type    string      `json:"type,omitempty"`
-	Agents  []Agents    `json:"agents,omitempty"`
+	Agents  []Agent     `json:"agents,omitempty"`
 	Tests   interface{} `json:"tests,omitempty"`
 }
 

--- a/group_label_test.go
+++ b/group_label_test.go
@@ -48,7 +48,7 @@ func TestClient_GetGroupLabelsByType(t *testing.T) {
 	assert.Equal(t, &expected, res)
 }
 
-func TestClient_GetGroupLabelsByID(t *testing.T) {
+func TestClient_GetGroupLabel(t *testing.T) {
 	out := `{
 		"groups" : [
 			{
@@ -64,17 +64,17 @@ func TestClient_GetGroupLabelsByID(t *testing.T) {
 	})
 
 	// Define expected values from the API (based on the JSON we print out above)
-	expected := GroupLabels{
-		GroupLabel{GroupLabelID: 222, BuiltIn: 0, GroupLabelType: "tests", GroupLabelName: "test-agent"},
+	expected := GroupLabel{
+		GroupLabelID: 222, BuiltIn: 0, GroupLabelType: "tests", GroupLabelName: "test-agent",
 	}
 
-	res, err := client.GetGroupLabelsByID(222)
+	res, err := client.GetGroupLabel(222)
 	teardown()
 	assert.Nil(t, err)
 	assert.Equal(t, &expected, res)
 }
 
-func TestClient_GetGroupLabelError(t *testing.T) {
+func TestClient_GetGroupLabelsError(t *testing.T) {
 	setup()
 	var client = &Client{APIEndpoint: server.URL, AuthToken: "foo"}
 	mux.HandleFunc("/groups.json", func(w http.ResponseWriter, r *http.Request) {
@@ -99,7 +99,7 @@ func TestClient_CreateGroupLabelError(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestClient_GetGroupLabelByIDError(t *testing.T) {
+func TestClient_GetGroupLabelError(t *testing.T) {
 	setup()
 	var client = &Client{APIEndpoint: server.URL, AuthToken: "foo"}
 	mux.HandleFunc("/groups/1.json", func(w http.ResponseWriter, r *http.Request) {
@@ -107,7 +107,7 @@ func TestClient_GetGroupLabelByIDError(t *testing.T) {
 		w.WriteHeader(http.StatusBadRequest)
 	})
 
-	_, err := client.GetGroupLabelsByID(1)
+	_, err := client.GetGroupLabel(1)
 	teardown()
 	assert.Error(t, err)
 }
@@ -177,11 +177,11 @@ func TestClient_CreateGroupLabel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := GroupLabels{GroupLabel{GroupLabelID: 1, GroupLabelName: "test"}}
+	expected := GroupLabel{GroupLabelID: 1, GroupLabelName: "test"}
 	assert.Equal(t, &expected, res)
 }
 
-func TestClient_GroupLabelJsonError(t *testing.T) {
+func TestClient_GroupLabelsJsonError(t *testing.T) {
 	out := `{"groups": [test]}`
 	setup()
 	var client = &Client{APIEndpoint: server.URL, AuthToken: "foo"}
@@ -194,7 +194,7 @@ func TestClient_GroupLabelJsonError(t *testing.T) {
 	assert.EqualError(t, err, "Could not decode JSON response: invalid character 'e' in literal true (expecting 'r')")
 }
 
-func TestClient_GroupLabelByTypeJsonError(t *testing.T) {
+func TestClient_GroupLabelsByTypeJsonError(t *testing.T) {
 	out := `{"groups": [test]}`
 	setup()
 	var client = &Client{APIEndpoint: server.URL, AuthToken: "foo"}
@@ -207,7 +207,7 @@ func TestClient_GroupLabelByTypeJsonError(t *testing.T) {
 	assert.EqualError(t, err, "Could not decode JSON response: invalid character 'e' in literal true (expecting 'r')")
 }
 
-func TestClient_GroupLabelByIDJsonError(t *testing.T) {
+func TestClient_GroupLabelError(t *testing.T) {
 	out := `{"groups": [test]}`
 	setup()
 	var client = &Client{APIEndpoint: server.URL, AuthToken: "foo"}
@@ -215,12 +215,12 @@ func TestClient_GroupLabelByIDJsonError(t *testing.T) {
 		assert.Equal(t, "GET", r.Method)
 		_, _ = w.Write([]byte(out))
 	})
-	_, err := client.GetGroupLabelsByID(1)
+	_, err := client.GetGroupLabel(1)
 	assert.Error(t, err)
 	assert.EqualError(t, err, "Could not decode JSON response: invalid character 'e' in literal true (expecting 'r')")
 }
 
-func TestClient_GetGroupLabelStatusCode(t *testing.T) {
+func TestClient_GetGroupLabelsStatusCode(t *testing.T) {
 	setup()
 	out := `{"groups":[{"groupId":1,"name":"test123"}]}`
 	var client = &Client{APIEndpoint: server.URL, AuthToken: "foo"}
@@ -234,6 +234,7 @@ func TestClient_GetGroupLabelStatusCode(t *testing.T) {
 	teardown()
 	assert.EqualError(t, err, "Failed call API endpoint. HTTP response code: 400. Error: &{}")
 }
+
 func TestClient_CreateGroupLabelJsonError(t *testing.T) {
 	out := `{"groups": [test]}`
 	setup()

--- a/group_label_test.go
+++ b/group_label_test.go
@@ -18,7 +18,7 @@ func TestClient_GetGroupLabels(t *testing.T) {
 
 	// Define expected values from the API (based on the JSON we print out above)
 	expected := GroupLabels{
-		GroupLabel{GroupLabelID: 1, GroupLabelType: "tests", GroupLabelName: "exampleName"},
+		GroupLabel{GroupID: 1, Type: "tests", Name: "exampleName"},
 	}
 
 	res, err := client.GetGroupLabels()
@@ -39,7 +39,7 @@ func TestClient_GetGroupLabelsByType(t *testing.T) {
 
 	// Define expected values from the API (based on the JSON we print out above)
 	expected := GroupLabels{
-		GroupLabel{GroupLabelID: 1, BuiltIn: 0, GroupLabelType: "tests", GroupLabelName: "test-agent"},
+		GroupLabel{GroupID: 1, BuiltIn: 0, Type: "tests", Name: "test-agent"},
 	}
 
 	res, err := client.GetGroupLabelsByType("tests")
@@ -65,7 +65,7 @@ func TestClient_GetGroupLabel(t *testing.T) {
 
 	// Define expected values from the API (based on the JSON we print out above)
 	expected := GroupLabel{
-		GroupLabelID: 222, BuiltIn: 0, GroupLabelType: "tests", GroupLabelName: "test-agent",
+		GroupID: 222, BuiltIn: 0, Type: "tests", Name: "test-agent",
 	}
 
 	res, err := client.GetGroupLabel(222)
@@ -153,12 +153,12 @@ func TestClient_UpdateGroupLabel(t *testing.T) {
 
 	var client = &Client{APIEndpoint: server.URL, AuthToken: "foo"}
 	id := 222
-	u := GroupLabel{GroupLabelType: "tests"}
+	u := GroupLabel{Type: "tests"}
 	res, err := client.UpdateGroupLabel(id, u)
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := GroupLabels{GroupLabel{GroupLabelID: 222, GroupLabelType: "tests", GroupLabelName: "test-agent"}}
+	expected := GroupLabels{GroupLabel{GroupID: 222, Type: "tests", Name: "test-agent"}}
 	assert.Equal(t, &expected, res)
 }
 
@@ -172,12 +172,12 @@ func TestClient_CreateGroupLabel(t *testing.T) {
 	})
 
 	var client = &Client{APIEndpoint: server.URL, AuthToken: "foo"}
-	u := GroupLabel{GroupLabelName: "test"}
+	u := GroupLabel{Name: "test"}
 	res, err := client.CreateGroupLabel(u)
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := GroupLabel{GroupLabelID: 1, GroupLabelName: "test"}
+	expected := GroupLabel{GroupID: 1, Name: "test"}
 	assert.Equal(t, &expected, res)
 }
 


### PR DESCRIPTION
* Corrects the process for looking up a label by ID
* Makes label struct names correspond to API names.